### PR TITLE
fix: fix form data being sent to backend

### DIFF
--- a/src/pages/DemoPayOS.jsx
+++ b/src/pages/DemoPayOS.jsx
@@ -38,7 +38,7 @@ export default function DemoPayOS() {
       const body = JSON.stringify({
         description: descriptionRef.current.value,
         productName: productNameRef.current.value,
-        price: Number(priceRef.current.value),
+        amount: Number(priceRef.current.value),
         returnUrl: RETURN_URL,
         cancelUrl: CANCEL_URL,
       });


### PR DESCRIPTION
Hi các bạn,

Theo như [payos-demo-nodejs/controllers/order-controller.js](https://github.com/payOSHQ/payos-demo-nodejs/blob/main/controllers/order-controller.js), các bạn đang expect `amount` . Nhưng trong form này, các bạn đang pass `price` đến backend. Mình mở PR này để sửa cho FE và BE example có thể work với nhau